### PR TITLE
added network access from jenkins to the creds-api

### DIFF
--- a/jenkins/docker-compose.yaml
+++ b/jenkins/docker-compose.yaml
@@ -12,7 +12,10 @@ services:
       - /Users/musatai/Jenkins/jenkins_home:/var/jenkins_home
     networks:
       - jenkins
+      - creds-api
 
 networks:
   jenkins:
     name: jenkins
+  creds-api:
+    name: creds-api


### PR DESCRIPTION
Jenkins need access to the creds-api service in order to perform operations on the aws servers